### PR TITLE
fix(frontend): replace non-existent Integration icon with Cable icon …

### DIFF
--- a/frontend/src/components/Settings/Settings.js
+++ b/frontend/src/components/Settings/Settings.js
@@ -49,7 +49,7 @@ import {
   Person as PersonIcon,
   SmartToy as AIIcon,
   Group as TeamIcon,
-  Integration as IntegrationIcon,
+  Cable as IntegrationIcon,
   Security as SecurityIcon,
   Notifications as NotificationsIcon,
   Palette as ThemeIcon,


### PR DESCRIPTION
…in Settings

- Replace 'Integration' import from @mui/icons-material with 'Cable'
- Resolves build error: 'Integration' is not exported from '@mui/icons-material'
- Cable icon is semantically appropriate for integrations section