### PR TITLE
fix(frontend): Add missing useEffect import in Upload component

### DIFF
--- a/frontend/src/components/Upload/Upload.js
+++ b/frontend/src/components/Upload/Upload.js
@@ -3,7 +3,7 @@
  * File upload and new startup application creation interface
  */
 
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Container,


### PR DESCRIPTION
- Fixed ESLint error: 'useEffect' is not defined no-undef
- Added useEffect to React imports in Upload.js line 6
- This resolves the frontend build failure during npm run build
- useEffect is used on line 149 for loading industries on component mount

Resolves: Frontend build failing with ESLint error
Test: Verified useEffect import and usage patterns
Impact: Enables successful frontend build completion