### PR TITLE
fix(frontend): resolve pipeline page TypeError - bottlenecks.map is n…

### DIFF
--- a/frontend/src/components/Pipeline/Pipeline.js
+++ b/frontend/src/components/Pipeline/Pipeline.js
@@ -110,9 +110,10 @@ const Pipeline = () => {
           manual_review: 68.4,
           partner_review: 85.0
         },
-        bottlenecks: [
-          { stage: 'ai_analysis', severity: 'medium', reason: 'High processing time' }
-        ]
+        bottlenecks: {
+          ai_analysis: 3,
+          data_processing: 2
+        }
       });
       
       // Fallback applications data

--- a/frontend/src/components/Pipeline/PipelineStats.js
+++ b/frontend/src/components/Pipeline/PipelineStats.js
@@ -44,9 +44,31 @@ const PipelineStats = ({ pipelineData, loading }) => {
     stages = {},
     conversion_rates = {},
     avg_days_per_stage = {},
-    bottlenecks = [],
+    bottlenecks = {},
     weekly_throughput = 0
   } = pipelineData;
+
+  // Convert bottlenecks to array for rendering - handle both dict and array formats
+  const bottleneckArray = React.useMemo(() => {
+    if (!bottlenecks) return [];
+    
+    // If already an array, return as is (for backward compatibility)
+    if (Array.isArray(bottlenecks)) {
+      return bottlenecks;
+    }
+    
+    // If it's a dictionary (expected format), convert to array
+    if (typeof bottlenecks === 'object') {
+      return Object.entries(bottlenecks).map(([stage, count]) => ({
+        stage,
+        count,
+        severity: count > 5 ? 'high' : count > 3 ? 'medium' : 'low',
+        reason: `${count} applications in ${stage.replace('_', ' ')} stage`
+      }));
+    }
+    
+    return [];
+  }, [bottlenecks]);
 
   const totalApplications = Object.values(stages).reduce((sum, count) => sum + count, 0);
   const completionRate = totalApplications > 0 ? ((stages.completed || 0) / totalApplications * 100) : 0;
@@ -200,7 +222,7 @@ const PipelineStats = ({ pipelineData, loading }) => {
               Pipeline Bottlenecks
             </Typography>
             
-            {bottlenecks.length === 0 ? (
+            {bottleneckArray.length === 0 ? (
               <Alert severity="success" icon={<CheckCircleIcon />}>
                 <Typography variant="body2">
                   No bottlenecks detected
@@ -211,7 +233,7 @@ const PipelineStats = ({ pipelineData, loading }) => {
               </Alert>
             ) : (
               <Box display="flex" flexDirection="column" gap={2}>
-                {bottlenecks.map((bottleneck, index) => (
+                {bottleneckArray.map((bottleneck, index) => (
                   <Alert 
                     key={index}
                     severity={bottleneck.severity === 'high' ? 'error' : 'warning'}


### PR DESCRIPTION
…ot a function

- Fix PipelineStats component to handle bottlenecks as dict instead of array
- Backend returns bottlenecks as {stage: count} dict but frontend expected array
- Add robust data handling to convert dict to array format for rendering
- Update fallback data in Pipeline component to match backend format
- Add React.useMemo for bottleneckArray to handle both dict and array formats
- Maintain backward compatibility for array format
- Fixes console error: TypeError: i.map is not a function at line 214